### PR TITLE
Cleanup initEnv

### DIFF
--- a/src/main/resources/initEnv
+++ b/src/main/resources/initEnv
@@ -4,11 +4,6 @@
 # Do not modify it by hand, as it will be overwritten by the   #
 # next execution of the wrapper task.                          #
 ################################################################
-not_sourced() {
-	test "X$(basename -- "$0")" = "XinitEnv"
-}
-# set stricter mode if invoked directly
-not_sourced && set -eu
 if [ -z "${APP_HOME:-}" ]; then
 	# Attempt to set APP_HOME
 	# Resolve links: $0 may be a link
@@ -27,7 +22,7 @@ if [ -z "${APP_HOME:-}" ]; then
 	cd "$(dirname "$PRG")/" >/dev/null
 	APP_HOME="$(pwd -P)"
 	cd "$SAVED" >/dev/null
-	not_sourced || echo "# APP_HOME not defined explicitly, using ${APP_HOME} to search for the config folder" >&2
+	echo "# APP_HOME not defined explicitly, using ${APP_HOME} to search for the config folder" >&2
 fi
 [ -z "${ADNDEVTOOLS_CACHE:-}" ] && export ADNDEVTOOLS_CACHE="$$$DEFAULT_ADNDEVTOOLS_CACHE_DIR$$$"
 BOOTSTRAP_SCRIPT_URL="$$$BOOTSTRAP_SCRIPT_URL$$$"
@@ -51,15 +46,3 @@ fi
 set -a
 eval "$VARS"
 set +a
-if not_sourced; then
-	# when the script is invoked directly, update gradle properties with up-to-date credentials
-	GRADLE_USER_HOME="${GRADLE_USER_HOME:-$HOME/.gradle}"
-	GRADLE_PROPERTIES="$GRADLE_USER_HOME/gradle.properties"
-	mkdir -p "$GRADLE_USER_HOME"
-	touch "$GRADLE_PROPERTIES"
-	sed -i -e '/^repoUser=/d' "$GRADLE_PROPERTIES"
-	echo "repoUser=$BINREPO_USER" >> "$GRADLE_PROPERTIES"
-	sed -i -e '/^repoPass=/d' "$GRADLE_PROPERTIES"
-	echo "repoPass=$BINREPO_TOKEN" >> "$GRADLE_PROPERTIES"
-	chmod 600 "$GRADLE_PROPERTIES"
-fi

--- a/src/main/resources/initEnv
+++ b/src/main/resources/initEnv
@@ -10,7 +10,6 @@ not_sourced() {
 # set stricter mode if invoked directly
 not_sourced && set -eu
 if [ -z "${APP_HOME:-}" ]; then
-	not_sourced || (echo "APP_HOME must be defined when sourcing initEnv" >&2 && return 1)
 	# Attempt to set APP_HOME
 	# Resolve links: $0 may be a link
 	PRG="$0"
@@ -28,6 +27,7 @@ if [ -z "${APP_HOME:-}" ]; then
 	cd "$(dirname "$PRG")/" >/dev/null
 	APP_HOME="$(pwd -P)"
 	cd "$SAVED" >/dev/null
+	not_sourced || echo "# APP_HOME not defined explicitly, using ${APP_HOME} to search for the config folder" >&2
 fi
 [ -z "${ADNDEVTOOLS_CACHE:-}" ] && export ADNDEVTOOLS_CACHE="$$$DEFAULT_ADNDEVTOOLS_CACHE_DIR$$$"
 BOOTSTRAP_SCRIPT_URL="$$$BOOTSTRAP_SCRIPT_URL$$$"

--- a/src/test/resources/initEnvEtalonCustom
+++ b/src/test/resources/initEnvEtalonCustom
@@ -4,13 +4,7 @@
 # Do not modify it by hand, as it will be overwritten by the   #
 # next execution of the wrapper task.                          #
 ################################################################
-not_sourced() {
-	test "X$(basename -- "$0")" = "XinitEnv"
-}
-# set stricter mode if invoked directly
-not_sourced && set -eu
 if [ -z "${APP_HOME:-}" ]; then
-	not_sourced || (echo "APP_HOME must be defined when sourcing initEnv" >&2 && return 1)
 	# Attempt to set APP_HOME
 	# Resolve links: $0 may be a link
 	PRG="$0"
@@ -28,6 +22,7 @@ if [ -z "${APP_HOME:-}" ]; then
 	cd "$(dirname "$PRG")/" >/dev/null
 	APP_HOME="$(pwd -P)"
 	cd "$SAVED" >/dev/null
+	echo "# APP_HOME not defined explicitly, using ${APP_HOME} to search for the config folder" >&2
 fi
 [ -z "${ADNDEVTOOLS_CACHE:-}" ] && export ADNDEVTOOLS_CACHE=".cache"
 BOOTSTRAP_SCRIPT_URL="https://mycustomscript"
@@ -51,15 +46,3 @@ fi
 set -a
 eval "$VARS"
 set +a
-if not_sourced; then
-	# when the script is invoked directly, update gradle properties with up-to-date credentials
-	GRADLE_USER_HOME="${GRADLE_USER_HOME:-$HOME/.gradle}"
-	GRADLE_PROPERTIES="$GRADLE_USER_HOME/gradle.properties"
-	mkdir -p "$GRADLE_USER_HOME"
-	touch "$GRADLE_PROPERTIES"
-	sed -i -e '/^repoUser=/d' "$GRADLE_PROPERTIES"
-	echo "repoUser=$BINREPO_USER" >> "$GRADLE_PROPERTIES"
-	sed -i -e '/^repoPass=/d' "$GRADLE_PROPERTIES"
-	echo "repoPass=$BINREPO_TOKEN" >> "$GRADLE_PROPERTIES"
-	chmod 600 "$GRADLE_PROPERTIES"
-fi

--- a/src/test/resources/initEnvEtalonDefault
+++ b/src/test/resources/initEnvEtalonDefault
@@ -4,13 +4,7 @@
 # Do not modify it by hand, as it will be overwritten by the   #
 # next execution of the wrapper task.                          #
 ################################################################
-not_sourced() {
-	test "X$(basename -- "$0")" = "XinitEnv"
-}
-# set stricter mode if invoked directly
-not_sourced && set -eu
 if [ -z "${APP_HOME:-}" ]; then
-	not_sourced || (echo "APP_HOME must be defined when sourcing initEnv" >&2 && return 1)
 	# Attempt to set APP_HOME
 	# Resolve links: $0 may be a link
 	PRG="$0"
@@ -28,6 +22,7 @@ if [ -z "${APP_HOME:-}" ]; then
 	cd "$(dirname "$PRG")/" >/dev/null
 	APP_HOME="$(pwd -P)"
 	cd "$SAVED" >/dev/null
+	echo "# APP_HOME not defined explicitly, using ${APP_HOME} to search for the config folder" >&2
 fi
 [ -z "${ADNDEVTOOLS_CACHE:-}" ] && export ADNDEVTOOLS_CACHE="$HOME/.cache/adndevtools"
 BOOTSTRAP_SCRIPT_URL="https://mycustomscript"
@@ -51,15 +46,3 @@ fi
 set -a
 eval "$VARS"
 set +a
-if not_sourced; then
-	# when the script is invoked directly, update gradle properties with up-to-date credentials
-	GRADLE_USER_HOME="${GRADLE_USER_HOME:-$HOME/.gradle}"
-	GRADLE_PROPERTIES="$GRADLE_USER_HOME/gradle.properties"
-	mkdir -p "$GRADLE_USER_HOME"
-	touch "$GRADLE_PROPERTIES"
-	sed -i -e '/^repoUser=/d' "$GRADLE_PROPERTIES"
-	echo "repoUser=$BINREPO_USER" >> "$GRADLE_PROPERTIES"
-	sed -i -e '/^repoPass=/d' "$GRADLE_PROPERTIES"
-	echo "repoPass=$BINREPO_TOKEN" >> "$GRADLE_PROPERTIES"
-	chmod 600 "$GRADLE_PROPERTIES"
-fi


### PR DESCRIPTION
- Remove capability to generate credentials to the user's gradle.properties file.
- Correct warning message for missing APP_HOME